### PR TITLE
Add type hints to all defs

### DIFF
--- a/nextline/count.py
+++ b/nextline/count.py
@@ -6,23 +6,23 @@ from nextline.types import PromptNo, RunNo, TaskNo, ThreadNo, TraceNo
 _T = TypeVar("_T", bound=int)
 
 
-def RunNoCounter(start=1) -> Callable[[], RunNo]:
+def RunNoCounter(start: int = 1) -> Callable[[], RunNo]:
     return CastedCounter(count(start).__next__, RunNo)
 
 
-def TraceNoCounter(start=1) -> Callable[[], TraceNo]:
+def TraceNoCounter(start: int = 1) -> Callable[[], TraceNo]:
     return CastedCounter(count(start).__next__, TraceNo)
 
 
-def ThreadNoCounter(start=1) -> Callable[[], ThreadNo]:
+def ThreadNoCounter(start: int = 1) -> Callable[[], ThreadNo]:
     return CastedCounter(count(start).__next__, ThreadNo)
 
 
-def TaskNoCounter(start=1) -> Callable[[], TaskNo]:
+def TaskNoCounter(start: int = 1) -> Callable[[], TaskNo]:
     return CastedCounter(count(start).__next__, TaskNo)
 
 
-def PromptNoCounter(start=1) -> Callable[[], PromptNo]:
+def PromptNoCounter(start: int = 1) -> Callable[[], PromptNo]:
     return CastedCounter(count(start).__next__, PromptNo)
 
 

--- a/nextline/disable.py
+++ b/nextline/disable.py
@@ -1,9 +1,10 @@
 import contextlib
 import sys
+from collections.abc import Iterator
 
 
 @contextlib.contextmanager
-def disable_trace():
+def disable_trace() -> Iterator[None]:
     '''Remove the system trace function temporarily.
 
     Example:

--- a/nextline/fsm/factory.py
+++ b/nextline/fsm/factory.py
@@ -149,7 +149,7 @@ CONFIG = {
 }
 
 
-def build_state_machine(model=None, graph=False, asyncio=True, markup=False) -> Machine:
+def build_state_machine(model=None, graph=False, asyncio=True, markup=False) -> Machine:  # type: ignore
     MachineClass: Type[Machine]
     if markup:
         MachineClass = MarkupMachine

--- a/nextline/fsm/state.py
+++ b/nextline/fsm/state.py
@@ -28,9 +28,9 @@ class Machine:
 
         assert self.state  # type: ignore
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         # e.g., "<Machine 'running'>"
-        return f'<{self.__class__.__name__} {self.state!r}>'
+        return f'<{self.__class__.__name__} {self.state!r}>'  # type: ignore
 
     async def after_state_change(self, event: EventData) -> None:
         if not (event.transition and event.transition.dest):
@@ -93,10 +93,10 @@ class Machine:
         # TODO: Check the arguments
         await self._hook.ahook.reset(*event.args, **event.kwargs)
 
-    async def __aenter__(self):
-        await self.initialize()
+    async def __aenter__(self) -> 'Machine':
+        await self.initialize()  # type: ignore
         return self
 
-    async def __aexit__(self, exc_type, exc_value, traceback):
+    async def __aexit__(self, exc_type, exc_value, traceback) -> None:  # type: ignore
         del exc_type, exc_value, traceback
-        await self.close()
+        await self.close()  # type: ignore

--- a/nextline/main.py
+++ b/nextline/main.py
@@ -66,7 +66,7 @@ class Nextline:
         self._started = False
         self._closed = False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         # e.g., "<Nextline 'running'>"
         return f'<{self.__class__.__name__} {self.state!r}>'
 
@@ -84,11 +84,11 @@ class Nextline:
         await self._machine.close()  # type: ignore
         await self._continuous.close()
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> 'Nextline':
         await self.start()
         return self
 
-    async def __aexit__(self, exc_type, exc_value, traceback):
+    async def __aexit__(self, exc_type, exc_value, traceback) -> None:  # type: ignore
         del exc_type, exc_value, traceback
         await asyncio.wait_for(self.close(), timeout=self._timeout_on_exit)
 
@@ -181,7 +181,7 @@ class Nextline:
         return self.subscribe("state_name")
 
     @property
-    def run_no(self):
+    def run_no(self) -> int:
         """The current run number"""
         return self.get("run_no")
 
@@ -198,12 +198,12 @@ class Nextline:
     def subscribe_trace_ids(self) -> AsyncIterator[tuple[int, ...]]:
         return self.subscribe("trace_nos")
 
-    def get_source(self, file_name=None):
+    def get_source(self, file_name: Optional[str] = None) -> list[str]:
         if not file_name or file_name == self._registry.latest("script_file_name"):
             return self.get("statement").split("\n")
         return [e.rstrip() for e in linecache.getlines(file_name)]
 
-    def get_source_line(self, line_no, file_name=None):
+    def get_source_line(self, line_no: int, file_name: Optional[str] = None) -> str:
         """
         based on linecache.getline()
         https://github.com/python/cpython/blob/v3.9.5/Lib/linecache.py#L26
@@ -250,10 +250,10 @@ class Nextline:
             assert isinstance(info, PromptInfo)
             yield info
 
-    def get(self, key) -> Any:
+    def get(self, key: Any) -> Any:
         return self._registry.latest(key)
 
-    def subscribe(self, key, last: Optional[bool] = True) -> AsyncIterator[Any]:
+    def subscribe(self, key: Any, last: Optional[bool] = True) -> AsyncIterator[Any]:
         return self._registry.subscribe(key, last=last)
 
     def subscribe_stdout(self) -> AsyncIterator[StdoutInfo]:

--- a/nextline/plugin/plugins/session/monitor.py
+++ b/nextline/plugin/plugins/session/monitor.py
@@ -17,7 +17,7 @@ class Monitor:
         self._queue = queue
         self._logger = getLogger(__name__)
 
-    async def open(self):
+    async def open(self) -> None:
         self._task = asyncio.create_task(self._monitor())
 
     async def close(self) -> None:
@@ -28,11 +28,11 @@ class Monitor:
         await asyncio.to_thread(self._queue.put, None)  # type: ignore
         await self._task
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> 'Monitor':
         await self.open()
         return self
 
-    async def __aexit__(self, exc_type, exc_value, traceback):
+    async def __aexit__(self, exc_type, exc_value, traceback):  # type: ignore
         del exc_type, exc_value, traceback
         await self.close()
 

--- a/nextline/plugin/plugins/session/monitor.py
+++ b/nextline/plugin/plugins/session/monitor.py
@@ -5,8 +5,7 @@ from logging import getLogger
 from apluggy import PluginManager
 
 from nextline import spawned
-
-from ....spawned import QueueOut
+from nextline.spawned import QueueOut
 
 # from rich import print
 

--- a/nextline/plugin/plugins/session/spawn.py
+++ b/nextline/plugin/plugins/session/spawn.py
@@ -18,7 +18,7 @@ from .monitor import Monitor
 pickling_support.install()
 
 
-def _call_all(*funcs) -> None:
+def _call_all(*funcs: Callable) -> None:
     '''Execute callables and ignore return values.
 
     Used to call multiple initializers in ProcessPoolExecutor.

--- a/nextline/plugin/spec.py
+++ b/nextline/plugin/spec.py
@@ -29,7 +29,7 @@ async def start() -> None:
 
 
 @hookspec
-async def close(exc_type=None, exc_value=None, traceback=None) -> None:
+async def close(exc_type=None, exc_value=None, traceback=None) -> None:  # type: ignore
     pass
 
 
@@ -63,7 +63,7 @@ async def on_initialize_run(run_arg: spawned.RunArg) -> None:
 
 @hookspec
 @apluggy.asynccontextmanager
-async def run():
+async def run():  # type: ignore
     yield
 
 

--- a/nextline/spawned/call.py
+++ b/nextline/spawned/call.py
@@ -1,5 +1,6 @@
 import sys
 import threading
+from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Optional
 
@@ -7,7 +8,9 @@ from .types import TraceFunction
 
 
 @contextmanager
-def sys_trace(trace_func: TraceFunction, thread: Optional[bool] = True):
+def sys_trace(
+    trace_func: TraceFunction, thread: Optional[bool] = True
+) -> Iterator[None]:
     '''Trace callables in the context and all threads created during the context.
 
     Notes

--- a/nextline/spawned/plugin/plugins/concurrency.py
+++ b/nextline/spawned/plugin/plugins/concurrency.py
@@ -39,7 +39,8 @@ class TaskAndThreadKeeper:
             yield
         finally:
             self._callback.close()
-            self._to_end and self._on_end(self._to_end)
+            if self._to_end:
+                self._on_end(self._to_end)
 
     @hookimpl
     def filtered(self) -> None:
@@ -57,7 +58,7 @@ class TaskAndThreadKeeper:
         self._counter()  # increment the counter
         self._hook.hook.on_start_task_or_thread()
 
-    def _on_end(self, ending: Task | Thread):
+    def _on_end(self, ending: Task | Thread) -> None:
         # The "ending" is not the "current" unless it is the main thread.
         self._logger.info(f'{self.__class__.__name__}._on_end: {ending}')
         self._hook.hook.on_end_task_or_thread(task_or_thread=ending)
@@ -89,7 +90,7 @@ class TaskOrThreadToTraceMapper:
         self._hook.hook.on_start_trace(trace_no=trace_no)
 
     @hookimpl
-    def on_end_task_or_thread(self, task_or_thread: Task | Thread):
+    def on_end_task_or_thread(self, task_or_thread: Task | Thread) -> None:
         trace_no = self._map[task_or_thread]
         self._hook.hook.on_end_trace(trace_no=trace_no)
         self._logger.info(f'{self.__class__.__name__} end: trace_no={trace_no}')

--- a/nextline/spawned/plugin/plugins/filter.py
+++ b/nextline/spawned/plugin/plugins/filter.py
@@ -17,7 +17,7 @@ class FilterByModuleName:
     '''Skip Python modules with names that match any of the patterns.'''
 
     @hookimpl
-    def init(self, modules_to_skip: Iterable[str]):
+    def init(self, modules_to_skip: Iterable[str]) -> None:
         self._patterns = frozenset(modules_to_skip)
 
         # NOTE: Use lru_cache() as match_any() is slow
@@ -91,7 +91,7 @@ class FilerByModule:
         self._add(trace_args)
         yield
 
-    def _add(self, trace_args: TraceArgs):
+    def _add(self, trace_args: TraceArgs) -> None:
         frame, _, _ = trace_args
         module_name = frame.f_globals.get('__name__')
         if module_name is None:

--- a/nextline/spawned/plugin/plugins/global_.py
+++ b/nextline/spawned/plugin/plugins/global_.py
@@ -1,5 +1,6 @@
 from logging import getLogger
-from typing import Optional
+from types import FrameType
+from typing import Any, Optional
 
 from apluggy import PluginManager
 
@@ -15,7 +16,9 @@ class TraceFuncCreator:
 
     @hookimpl
     def create_trace_func(self) -> TraceFunction:
-        def _trace_func(frame, event, arg) -> Optional[TraceFunction]:
+        def _trace_func(
+            frame: FrameType, event: str, arg: Any
+        ) -> Optional[TraceFunction]:
             try:
                 return self._hook.hook.global_trace_func(
                     frame=frame, event=event, arg=arg
@@ -33,7 +36,9 @@ class GlobalTraceFunc:
         self._hook = hook
 
     @hookimpl
-    def global_trace_func(self, frame, event, arg) -> Optional[TraceFunction]:
+    def global_trace_func(
+        self, frame: FrameType, event: str, arg: Any
+    ) -> Optional[TraceFunction]:
         if self._hook.hook.filter(trace_args=(frame, event, arg)):
             return None
         self._hook.hook.filtered(trace_args=(frame, event, arg))

--- a/nextline/spawned/plugin/plugins/pdb_/custom.py
+++ b/nextline/spawned/plugin/plugins/pdb_/custom.py
@@ -1,6 +1,6 @@
 from logging import getLogger
 from pdb import Pdb
-from typing import IO, Callable, ContextManager
+from typing import IO, Any, Callable, ContextManager
 
 from nextline.spawned.exc import NotOnTraceCall
 
@@ -43,7 +43,7 @@ class CustomizedPdb(Pdb):
         # super()._cmdloop()
         self.cmdloop()
 
-    def cmdloop(self, intro=None) -> None:
+    def cmdloop(self, intro: Any | None = None) -> None:
         '''Override Cmd.cmdloop() to call it inside a context manager.'''
         try:
             with self._cmdloop_hook():
@@ -52,7 +52,7 @@ class CustomizedPdb(Pdb):
             logger = getLogger(__name__)
             logger.exception('')
 
-    def set_continue(self):
+    def set_continue(self) -> None:
         '''Override Bdb.set_continue() to avoid sys.settrace(None).'''
         # super().set_continue()
-        self._set_stopinfo(self.botframe, None, -1)
+        self._set_stopinfo(self.botframe, None, -1)  # type: ignore

--- a/nextline/spawned/plugin/plugins/pdb_/factory.py
+++ b/nextline/spawned/plugin/plugins/pdb_/factory.py
@@ -1,4 +1,5 @@
 from logging import getLogger
+from typing import Any, Callable, ContextManager
 
 from apluggy import PluginManager
 
@@ -30,11 +31,11 @@ class PdbInstanceFactory:
         return self._factory()
 
 
-def Factory(hook: PluginManager):
+def Factory(hook: PluginManager) -> Callable[[], TraceFunction]:
     cmdloop_hook = CmdloopHook(hook=hook)
     prompt_func = PromptFunc(hook=hook)
 
-    def _factory():
+    def _factory() -> TraceFunction:
         stdio = StdInOut(prompt_func=prompt_func)
         pdb = CustomizedPdb(
             cmdloop_hook=cmdloop_hook,
@@ -47,10 +48,10 @@ def Factory(hook: PluginManager):
     return _factory
 
 
-def CmdloopHook(hook: PluginManager):
+def CmdloopHook(hook: PluginManager) -> Callable[[], ContextManager[Any]]:
     '''Return a context manager in which Pdb.cmdloop() is called.'''
 
-    def cmdloop():
+    def cmdloop() -> ContextManager[Any]:
         if not hook.hook.is_on_trace_call():
             raise NotOnTraceCall
         return hook.with_.on_cmdloop()

--- a/nextline/spawned/plugin/plugins/pdb_/prompt.py
+++ b/nextline/spawned/plugin/plugins/pdb_/prompt.py
@@ -61,7 +61,7 @@ class Prompt:
 
 
 @contextmanager
-def relay_commands(queue_in: QueueIn, queue_map: QueueMap):
+def relay_commands(queue_in: QueueIn, queue_map: QueueMap) -> Iterator[None]:
     '''Pass the Pdb commands from the main process to the Pdb instances.'''
     logger = getLogger(__name__)
 

--- a/nextline/spawned/plugin/plugins/pdb_/stream.py
+++ b/nextline/spawned/plugin/plugins/pdb_/stream.py
@@ -56,11 +56,11 @@ class StdInOut(TextIOWrapper):
         self._prompt_text += s
         return len(s)
 
-    def flush(self):
+    def flush(self) -> None:
         '''To replace stdout.flush()'''
         pass
 
-    def readline(self):
+    def readline(self) -> str:  # type: ignore
         '''Call the prompt_func() with the text given to write() and return the result.
 
         For example, Pdb calls this method as stdin.readline() for user command.

--- a/nextline/spawned/plugin/plugins/peek.py
+++ b/nextline/spawned/plugin/plugins/peek.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from collections.abc import Callable, Iterator
-from typing import Any, TypeVar
+from typing import Any, ContextManager, TypeVar
 
 from apluggy import PluginManager, contextmanager
 
@@ -27,7 +27,7 @@ class PeekStdout:
     def _key_factory(self) -> TraceNo | None:
         return self._hook.hook.current_trace_no()
 
-    def _callback(self, trace_no: TraceNo, line: str):
+    def _callback(self, trace_no: TraceNo, line: str) -> None:
         self._hook.hook.on_write_stdout(trace_no=trace_no, line=line)
 
 
@@ -37,7 +37,7 @@ _T = TypeVar('_T')
 def peek_stdout_by_key(
     key_factory: Callable[[], _T | None],
     callback: Callable[[_T, str], Any],
-):
+) -> ContextManager[Callable[[str], int]]:
     callback_ = ReadLinesByKey(callback)
     assign_key = AssignKey(key_factory=key_factory, callback=callback_)
     return peek_stdout(assign_key)

--- a/nextline/spawned/plugin/plugins/repeat.py
+++ b/nextline/spawned/plugin/plugins/repeat.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Generator
+from collections.abc import Generator, Iterator
 
 from apluggy import PluginManager, contextmanager
 
@@ -22,12 +22,12 @@ from nextline.types import PromptNo, TraceNo
 
 class Repeater:
     @hookimpl
-    def init(self, hook: PluginManager, queue_out: QueueOut):
+    def init(self, hook: PluginManager, queue_out: QueueOut) -> None:
         self._hook = hook
         self._queue_out = queue_out
 
     @hookimpl
-    def on_start_trace(self, trace_no: TraceNo):
+    def on_start_trace(self, trace_no: TraceNo) -> None:
         assert trace_no == self._hook.hook.current_trace_no()
         started_at = datetime.datetime.utcnow()
         thread_no = self._hook.hook.current_thread_no()
@@ -48,7 +48,7 @@ class Repeater:
 
     @hookimpl
     @contextmanager
-    def on_trace_call(self, trace_args: TraceArgs):
+    def on_trace_call(self, trace_args: TraceArgs) -> Iterator[None]:
         started_at = datetime.datetime.utcnow()
         trace_no = self._hook.hook.current_trace_no()
         frame, call_event, call_arg = trace_args
@@ -115,7 +115,7 @@ class Repeater:
             self._queue_out.put(event_end)
 
     @hookimpl
-    def on_write_stdout(self, trace_no: TraceNo, line: str):
+    def on_write_stdout(self, trace_no: TraceNo, line: str) -> None:
         written_at = datetime.datetime.utcnow()
         trace_no = self._hook.hook.current_trace_no()
         event = OnWriteStdout(

--- a/nextline/spawned/plugin/spec.py
+++ b/nextline/spawned/plugin/spec.py
@@ -36,7 +36,7 @@ def init(
 
 @hookspec
 @apluggy.contextmanager
-def context():
+def context():  # type: ignore
     pass
 
 
@@ -56,7 +56,9 @@ def finalize_run_result(run_result: RunResult) -> None:
 
 
 @hookspec(firstresult=True)
-def global_trace_func(frame: FrameType, event, arg) -> Optional[TraceFunction]:
+def global_trace_func(
+    frame: FrameType, event: str, arg: Any
+) -> Optional[TraceFunction]:
     pass
 
 
@@ -75,7 +77,7 @@ def filtered(trace_args: TraceArgs) -> None:
 
 
 @hookspec(firstresult=True)
-def local_trace_func(frame: FrameType, event, arg) -> Optional[TraceFunction]:
+def local_trace_func(frame: FrameType, event: str, arg: Any) -> Optional[TraceFunction]:
     pass
 
 
@@ -90,7 +92,7 @@ def on_start_task_or_thread() -> None:
 
 
 @hookspec
-def on_end_task_or_thread(task_or_thread: Task | Thread):
+def on_end_task_or_thread(task_or_thread: Task | Thread) -> None:
     pass
 
 
@@ -121,7 +123,7 @@ def on_end_trace(trace_no: TraceNo) -> None:
 
 @hookspec
 @apluggy.contextmanager
-def on_trace_call(trace_args: TraceArgs):
+def on_trace_call(trace_args: TraceArgs):  # type: ignore
     pass
 
 
@@ -137,7 +139,7 @@ def current_trace_args() -> Optional[TraceArgs]:
 
 @hookspec
 @apluggy.contextmanager
-def on_cmdloop():
+def on_cmdloop():  # type: ignore
     pass
 
 

--- a/nextline/spawned/utils.py
+++ b/nextline/spawned/utils.py
@@ -13,7 +13,9 @@ def WithContext(
     def _create_local_trace() -> TraceFunction:
         next_trace: TraceFunction | None = trace
 
-        def _local_trace(frame, event, arg) -> Optional[TraceFunction]:
+        def _local_trace(
+            frame: FrameType, event: str, arg: Any
+        ) -> Optional[TraceFunction]:
             nonlocal next_trace
             assert next_trace
             with context(frame, event, arg):
@@ -23,7 +25,9 @@ def WithContext(
 
         return _local_trace
 
-    def _global_trace(frame: FrameType, event, arg) -> Optional[TraceFunction]:
+    def _global_trace(
+        frame: FrameType, event: str, arg: Any
+    ) -> Optional[TraceFunction]:
         return _create_local_trace()(frame, event, arg)
 
     return _global_trace

--- a/nextline/utils/done_callback/task.py
+++ b/nextline/utils/done_callback/task.py
@@ -80,7 +80,7 @@ class TaskDoneCallback:
         while self._active:
             time.sleep(interval)
 
-    def _callback(self, task: Task, *_, **__):
+    def _callback(self, task: Task, *_: Any, **__: Any) -> None:
         """This method is given to asyncio.Task.add_done_callback()
 
         When called, this method, in turn, calls the callback function
@@ -101,16 +101,16 @@ class TaskDoneCallback:
         except BaseException as e:
             self._exceptions.append(e)
 
-    def __enter__(self):
+    def __enter__(self) -> "TaskDoneCallback":
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback):  # type: ignore
         del exc_type, exc_value, traceback
         self.close()
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> "TaskDoneCallback":
         return self
 
-    async def __aexit__(self, exc_type, exc_value, traceback):
+    async def __aexit__(self, exc_type, exc_value, traceback):  # type: ignore
         del exc_type, exc_value, traceback
         await self.aclose()

--- a/nextline/utils/done_callback/thread.py
+++ b/nextline/utils/done_callback/thread.py
@@ -63,7 +63,7 @@ class ThreadDoneCallback:
         self._closed = True
         self._t.join()
 
-    def _monitor(self):
+    def _monitor(self) -> None:
         exc = []
         while True:
             if done := {t for t in self._active if not t.is_alive()}:
@@ -82,9 +82,9 @@ class ThreadDoneCallback:
         if exc:
             raise exc[0]
 
-    def __enter__(self):
+    def __enter__(self) -> "ThreadDoneCallback":
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback):  # type: ignore
         del exc_type, exc_value, traceback
         self.close()

--- a/nextline/utils/done_callback/union.py
+++ b/nextline/utils/done_callback/union.py
@@ -35,16 +35,16 @@ class ThreadTaskDoneCallback:
         await self._task_callback.aclose(interval=interval)
         await to_thread(self._thread_callback.close)
 
-    def __enter__(self):
+    def __enter__(self) -> "ThreadTaskDoneCallback":
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback):  # type: ignore
         del exc_type, exc_value, traceback
         self.close()
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> "ThreadTaskDoneCallback":
         return self
 
-    async def __aexit__(self, exc_type, exc_value, traceback):
+    async def __aexit__(self, exc_type, exc_value, traceback):  # type: ignore
         del exc_type, exc_value, traceback
         await self.aclose()

--- a/nextline/utils/multiprocessing_logging.py
+++ b/nextline/utils/multiprocessing_logging.py
@@ -11,7 +11,7 @@ from typing import Callable, Optional, cast
 __all__ = ['MultiprocessingLogging']
 
 
-def example_func():
+def example_func() -> None:
     '''Used in doctest, defined here to be picklable.'''
     logger = logging.getLogger(__name__)
     logger.warning('warning from another process')
@@ -84,7 +84,7 @@ class MultiprocessingLogging:
         '''A callable with no args to be given to ProcessPoolExecutor as initializer.'''
         return self._initializer
 
-    async def open(self):
+    async def open(self) -> None:
         self._task = asyncio.create_task(self._listen())
 
     async def _listen(self) -> None:
@@ -100,11 +100,11 @@ class MultiprocessingLogging:
             await self._task
             self._task = None
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> 'MultiprocessingLogging':
         await self.open()
         return self
 
-    async def __aexit__(self, exc_type, exc_value, traceback) -> None:
+    async def __aexit__(self, exc_type, exc_value, traceback) -> None:  # type: ignore
         del exc_type, exc_value, traceback
         await self.close()
 

--- a/nextline/utils/peek.py
+++ b/nextline/utils/peek.py
@@ -1,9 +1,10 @@
 import sys
+from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Any, Callable, TextIO
+from typing import Any, Callable, ContextManager, TextIO
 
 
-def peek_stdout(callback: Callable[[str], Any]):
+def peek_stdout(callback: Callable[[str], Any]) -> ContextManager[Callable[[str], int]]:
     '''A context manager that executes the callback with text written to stdout.
 
     Example:
@@ -34,13 +35,15 @@ def peek_stdout(callback: Callable[[str], Any]):
     return peek_textio(sys.stdout, callback)
 
 
-def peek_stderr(callback: Callable[[str], Any]):
+def peek_stderr(callback: Callable[[str], Any]) -> ContextManager[Callable[[str], int]]:
     '''A context manager that executes the callback with text written to stderr.'''
     return peek_textio(sys.stderr, callback)
 
 
 @contextmanager
-def peek_textio(textio: TextIO, callback: Callable[[str], Any]):
+def peek_textio(
+    textio: TextIO, callback: Callable[[str], Any]
+) -> Iterator[Callable[[str], int]]:
     '''A context manager that executes the callback with text written to the textio.'''
 
     org_write = textio.write

--- a/nextline/utils/pubsub/broker.py
+++ b/nextline/utils/pubsub/broker.py
@@ -54,9 +54,9 @@ class PubSub(Generic[_KT, _VT]):
             _, q = self._queue.popitem()
             await q.close()
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> "PubSub[_KT, _VT]":
         return self
 
-    async def __aexit__(self, exc_type, exc_value, traceback):
+    async def __aexit__(self, exc_type, exc_value, traceback) -> None:  # type: ignore
         del exc_type, exc_value, traceback
         await self.close()

--- a/nextline/utils/pubsub/item.py
+++ b/nextline/utils/pubsub/item.py
@@ -155,10 +155,10 @@ class PubSubItem(Generic[_T]):
             self._closed = True
             await self._publish(_M.END)
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> "PubSubItem[_T]":
         return self
 
-    async def __aexit__(self, exc_type, exc_value, traceback):
+    async def __aexit__(self, exc_type, exc_value, traceback) -> None:  # type: ignore
         del exc_type, exc_value, traceback
         await self.close()
 

--- a/nextline/utils/run.py
+++ b/nextline/utils/run.py
@@ -39,7 +39,7 @@ class RunningProcess(Generic[_T]):
         self._process_created_at_fmt = self._format_time(self.process_created_at)
         self._log_created()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         ret = (
             f'<{self.__class__.__name__}'
             f' pid={self.process.pid!r}'

--- a/nextline/utils/thread_exception.py
+++ b/nextline/utils/thread_exception.py
@@ -9,15 +9,15 @@ class ExcThread(Thread):
 
     """
 
-    def run(self):
+    def run(self) -> None:
         self.exc = None
         try:
             return super().run()
         except BaseException as e:
             self.exc = e
 
-    def join(self):
-        ret = super().join()
+    def join(self, timeout: float | None = None) -> None:
+        ret = super().join(timeout)
         if self.exc:
             raise self.exc
         return ret

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ target_version = ['py310', 'py311', 'py312']
 profile = "black"
 
 [tool.mypy]
+# disallow_untyped_defs = true
 exclude = ['script\.py']
 
 

--- a/tests/main/scenarios/test_example.py
+++ b/tests/main/scenarios/test_example.py
@@ -246,6 +246,7 @@ async def control_trace(nextline: Nextline, trace_no):
             assert nextline.get_source(file_name)
         command = 'next'
         if s.event == 'line':
+            assert s.line_no is not None
             line = nextline.get_source_line(
                 line_no=s.line_no,
                 file_name=s.file_name,


### PR DESCRIPTION
The option disallow_untyped_defs on nextline/ shows no error.
The folder tests/ still contain untyped defs.
