### PR TITLE
Trace only the main scrip

### DIFF
--- a/nextline/spawned/plugin/plugins/__init__.py
+++ b/nextline/spawned/plugin/plugins/__init__.py
@@ -5,7 +5,7 @@ from apluggy import PluginManager
 
 from .compose import CallableComposer
 from .concurrency import TaskAndThreadKeeper, TaskOrThreadToTraceMapper
-from .filter import FilerByModule, FilterByModuleName, FilterLambda
+from .filter import FilerByModule, FilterByModuleName, FilterLambda, FilterMainScript
 from .global_ import GlobalTraceFunc, TraceFuncCreator
 from .local_ import LocalTraceFunc, TraceCallHandler
 from .pdb_ import PdbInstanceFactory, Prompt
@@ -22,9 +22,10 @@ def register(hook: PluginManager) -> None:
     hook.register(LocalTraceFunc)
     hook.register(TaskOrThreadToTraceMapper)
     hook.register(TaskAndThreadKeeper)
-    hook.register(FilerByModule)
+    # hook.register(FilerByModule)
     hook.register(FilterLambda)
-    hook.register(FilterByModuleName)
+    # hook.register(FilterByModuleName)
+    hook.register(FilterMainScript)
     hook.register(GlobalTraceFunc)
     hook.register(TraceFuncCreator)
     hook.register(CallableComposer)

--- a/nextline/spawned/plugin/plugins/filter.py
+++ b/nextline/spawned/plugin/plugins/filter.py
@@ -12,6 +12,8 @@ from nextline.spawned.plugin.spec import hookimpl
 from nextline.spawned.types import TraceArgs
 from nextline.utils import current_task_or_thread, match_any
 
+from . import _script
+
 
 class FilterByModuleName:
     '''Skip Python modules with names that match any of the patterns.'''
@@ -39,6 +41,18 @@ class FilterLambda:
         frame = trace_args[0]
         func_name = frame.f_code.co_name
         return func_name == '<lambda>' or None
+
+
+class FilterMainScript:
+    '''Skip lambda functions.'''
+
+    @hookimpl
+    def filter(self, trace_args: TraceArgs) -> bool | None:
+        frame = trace_args[0]
+        module_name = frame.f_globals.get('__name__')
+        if _script.__name__ == module_name:
+            return False
+        return True
 
 
 class FilerByModule:


### PR DESCRIPTION
With this PR, nextline only traces the main script. Problems caused by tracing many different modules will not occur. On the other hand, the `step` command cannot be used to step into another module. It is still possible to step into a function defined in the main script.

This is a quick fix. The change is hard-coded. I'll make this a configurable toggle in the future.
