### PR TITLE
Revert https://github.com/simonsobs/nextline/pull/20 partially

### DIFF
--- a/nextline/__init__.py
+++ b/nextline/__init__.py
@@ -2,13 +2,9 @@ __all__ = [
     '__version__',
     'disable_trace',
     'Nextline',
-    'InitOptions',
-    'ResetOptions',
-    'Statement',
 ]
 
 from nextline.__about__ import __version__
 
 from .disable import disable_trace
 from .main import Nextline
-from .types import InitOptions, ResetOptions, Statement

--- a/nextline/__init__.py
+++ b/nextline/__init__.py
@@ -2,9 +2,11 @@ __all__ = [
     '__version__',
     'disable_trace',
     'Nextline',
+    'Statement',
 ]
 
 from nextline.__about__ import __version__
 
 from .disable import disable_trace
 from .main import Nextline
+from .types import Statement

--- a/nextline/main.py
+++ b/nextline/main.py
@@ -32,16 +32,40 @@ class Nextline:
     Nextline supports concurrency with threading and asyncio. It uses multiple
     instances of Pdb, one for each thread and async task.
 
+
+    Parameters
+    ----------
+    statement : str or Path or CodeType or Callable[[], Any]
+        A Python code as a str, a Path object that points to a Python script,
+        a CodeType object, or a callable with no arguments. It must be
+        picklable.
+    run_no_start_from : int, optional
+        The first run number. The default is 1.
+    timeout_on_exit : float, optional
+        The timeout in seconds to wait for the nextline to exit from the "with"
+        block. The default is 3.
+
     '''
 
-    def __init__(self, init_options: InitOptions):
+    def __init__(
+        self,
+        statement: str | Path | CodeType | Callable[[], Any],
+        run_no_start_from: int = 1,
+        timeout_on_exit: float = 3,
+    ):
         logger = getLogger(__name__)
-        logger.debug(f'init_options: {reprlib.repr(init_options)}')
+        logger.debug(f'statement: {reprlib.repr(statement)}')
+        logger.debug(f"The run number starts from {run_no_start_from}")
 
         self._continuous = Continuous(self)
 
+        init_options = InitOptions(
+            statement=statement,
+            run_no_start_from=run_no_start_from,
+        )
+
         self._machine = Machine(init_options=init_options)
-        self._timeout_on_exit = init_options.timeout_on_exit
+        self._timeout_on_exit = timeout_on_exit
         self._registry = self._machine.registry
 
         self._started = False

--- a/nextline/main.py
+++ b/nextline/main.py
@@ -39,6 +39,12 @@ class Nextline:
         picklable.
     run_no_start_from : int, optional
         The first run number. The default is 1.
+    trace_threads : bool, optional
+        The default is False. If False, trace only the main thread. If True,
+        trace all threads.
+    trace_modules : bool, optional
+        The default is False. If False, trace only the statement. If True,
+        trace imported modules as well.
     timeout_on_exit : float, optional
         The timeout in seconds to wait for the nextline to exit from the "with"
         block. The default is 3.
@@ -49,18 +55,21 @@ class Nextline:
         self,
         statement: Statement,
         run_no_start_from: int = 1,
+        trace_threads: bool = False,
+        trace_modules: bool = False,
         timeout_on_exit: float = 3,
     ):
-        logger = getLogger(__name__)
-        logger.debug(f'statement: {reprlib.repr(statement)}')
-        logger.debug(f"The run number starts from {run_no_start_from}")
-
         self._continuous = Continuous(self)
 
         init_options = InitOptions(
             statement=statement,
             run_no_start_from=run_no_start_from,
+            trace_threads=trace_threads,
+            trace_modules=trace_modules,
         )
+
+        logger = getLogger(__name__)
+        logger.debug(f'init_options: {reprlib.repr(init_options)}')
 
         self._machine = Machine(init_options=init_options)
         self._timeout_on_exit = timeout_on_exit
@@ -156,12 +165,18 @@ class Nextline:
         self,
         statement: Optional[Statement] = None,
         run_no_start_from: Optional[int] = None,
+        trace_threads: Optional[bool] = None,
+        trace_modules: Optional[bool] = None,
     ) -> None:
         """Prepare for the next run"""
         reset_options = ResetOptions(
             statement=statement,
             run_no_start_from=run_no_start_from,
+            trace_threads=trace_threads,
+            trace_modules=trace_modules,
         )
+        logger = getLogger(__name__)
+        logger.debug(f'reset_options: {reprlib.repr(reset_options)}')
         await self._machine.reset(  # type: ignore
             reset_options=reset_options,
         )

--- a/nextline/main.py
+++ b/nextline/main.py
@@ -1,10 +1,13 @@
 import asyncio
 import linecache
 import reprlib
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from logging import getLogger
+from pathlib import Path
+from types import CodeType
 from typing import Any, Optional
+
 
 from .continuous import Continuous
 from .fsm import Machine
@@ -127,9 +130,16 @@ class Nextline:
         '''Return value of the last run. None unless the statement is a callable.'''
         return self._machine.result()
 
-    async def reset(self, reset_options: Optional[ResetOptions] = None) -> None:
+    async def reset(
+        self,
+        statement: str | Path | CodeType | Callable[[], Any] | None = None,
+        run_no_start_from: Optional[int] = None,
+    ) -> None:
         """Prepare for the next run"""
-        reset_options = reset_options or ResetOptions()
+        reset_options = ResetOptions(
+            statement=statement,
+            run_no_start_from=run_no_start_from,
+        )
         await self._machine.reset(  # type: ignore
             reset_options=reset_options,
         )

--- a/nextline/main.py
+++ b/nextline/main.py
@@ -1,13 +1,10 @@
 import asyncio
 import linecache
 import reprlib
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from logging import getLogger
-from pathlib import Path
-from types import CodeType
 from typing import Any, Optional
-
 
 from .continuous import Continuous
 from .fsm import Machine
@@ -19,6 +16,7 @@ from .types import (
     PromptNotice,
     ResetOptions,
     RunInfo,
+    Statement,
     StdoutInfo,
     TraceInfo,
     TraceNo,
@@ -49,7 +47,7 @@ class Nextline:
 
     def __init__(
         self,
-        statement: str | Path | CodeType | Callable[[], Any],
+        statement: Statement,
         run_no_start_from: int = 1,
         timeout_on_exit: float = 3,
     ):
@@ -156,7 +154,7 @@ class Nextline:
 
     async def reset(
         self,
-        statement: str | Path | CodeType | Callable[[], Any] | None = None,
+        statement: Optional[Statement] = None,
         run_no_start_from: Optional[int] = None,
     ) -> None:
         """Prepare for the next run"""

--- a/nextline/types.py
+++ b/nextline/types.py
@@ -28,7 +28,6 @@ class InitOptions:
     run_no_start_from: int = 1
     trace_threads: bool = False
     trace_modules: bool = False
-    timeout_on_exit: float = 3  # in seconds
 
 
 @dataclasses.dataclass

--- a/tests/main/scenarios/test_example.py
+++ b/tests/main/scenarios/test_example.py
@@ -288,7 +288,7 @@ def extract_comment(line: str) -> Optional[str]:
 
 @pytest.fixture
 async def nextline(statement):
-    async with Nextline(statement) as y:
+    async with Nextline(statement, trace_threads=True, trace_modules=True) as y:
         yield y
 
 

--- a/tests/main/scenarios/test_example.py
+++ b/tests/main/scenarios/test_example.py
@@ -2,7 +2,7 @@ import asyncio
 import dataclasses
 import datetime
 from collections import Counter, deque
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import Sequence
 from functools import partial
 from itertools import groupby
 from operator import attrgetter
@@ -11,7 +11,7 @@ from typing import Any, Optional
 
 import pytest
 
-from nextline import InitOptions, Nextline, Statement
+from nextline import Nextline
 from nextline.types import RunInfo, RunNo
 from nextline.utils import agen_with_wait
 
@@ -287,11 +287,8 @@ def extract_comment(line: str) -> Optional[str]:
 
 
 @pytest.fixture
-async def nextline(statement: Statement) -> AsyncIterator[Nextline]:
-    init_options = InitOptions(
-        statement=statement, trace_threads=True, trace_modules=True
-    )
-    async with Nextline(init_options=init_options) as y:
+async def nextline(statement):
+    async with Nextline(statement) as y:
         yield y
 
 

--- a/tests/main/scenarios/test_interruption.py
+++ b/tests/main/scenarios/test_interruption.py
@@ -2,12 +2,11 @@ import asyncio
 import dataclasses
 import datetime
 from collections import deque
-from collections.abc import AsyncIterator
 from functools import partial
 
 import pytest
 
-from nextline import InitOptions, Nextline, Statement
+from nextline import Nextline
 from nextline.types import RunInfo, RunNo
 
 from .funcs import replace_with_bool
@@ -99,9 +98,8 @@ async def control(nextline: Nextline):
 
 
 @pytest.fixture
-async def nextline(statement: Statement) -> AsyncIterator[Nextline]:
-    init_options = InitOptions(statement=statement)
-    async with Nextline(init_options=init_options) as y:
+async def nextline(statement):
+    async with Nextline(statement) as y:
         yield y
 
 

--- a/tests/main/scenarios/test_kill.py
+++ b/tests/main/scenarios/test_kill.py
@@ -1,9 +1,8 @@
 import asyncio
-from collections.abc import AsyncIterator
 
 import pytest
 
-from nextline import InitOptions, Nextline, Statement
+from nextline import Nextline
 
 STATEMENT = """
 import time
@@ -46,9 +45,8 @@ async def control(nextline: Nextline):
 
 
 @pytest.fixture
-async def nextline(statement: Statement) -> AsyncIterator[Nextline]:
-    init_options = InitOptions(statement=statement)
-    async with Nextline(init_options=init_options) as y:
+async def nextline(statement):
+    async with Nextline(statement) as y:
         yield y
 
 

--- a/tests/main/scenarios/test_raise.py
+++ b/tests/main/scenarios/test_raise.py
@@ -2,12 +2,11 @@ import asyncio
 import dataclasses
 import datetime
 from collections import deque
-from collections.abc import AsyncIterator
 from functools import partial
 
 import pytest
 
-from nextline import InitOptions, Nextline, Statement
+from nextline import Nextline
 from nextline.types import RunInfo, RunNo
 
 from .funcs import replace_with_bool
@@ -98,9 +97,8 @@ async def control(nextline: Nextline):
 
 
 @pytest.fixture
-async def nextline(statement: Statement) -> AsyncIterator[Nextline]:
-    init_options = InitOptions(statement=statement)
-    async with Nextline(init_options=init_options) as y:
+async def nextline(statement):
+    async with Nextline(statement) as y:
         yield y
 
 

--- a/tests/main/scenarios/test_simple.py
+++ b/tests/main/scenarios/test_simple.py
@@ -1,9 +1,8 @@
 import asyncio
-from collections.abc import AsyncIterator
 
 import pytest
 
-from nextline import InitOptions, Nextline, Statement
+from nextline import Nextline
 
 STATEMENT = """
 import time
@@ -41,9 +40,8 @@ async def control(nextline: Nextline):
 
 
 @pytest.fixture
-async def nextline(statement: Statement) -> AsyncIterator[Nextline]:
-    init_options = InitOptions(statement=statement)
-    async with Nextline(init_options=init_options) as y:
+async def nextline(statement):
+    async with Nextline(statement) as y:
         yield y
 
 

--- a/tests/main/scenarios/test_terminate.py
+++ b/tests/main/scenarios/test_terminate.py
@@ -1,9 +1,8 @@
 import asyncio
-from collections.abc import AsyncIterator
 
 import pytest
 
-from nextline import InitOptions, Nextline, Statement
+from nextline import Nextline
 
 STATEMENT = """
 import time
@@ -46,9 +45,8 @@ async def control(nextline: Nextline):
 
 
 @pytest.fixture
-async def nextline(statement: Statement) -> AsyncIterator[Nextline]:
-    init_options = InitOptions(statement=statement)
-    async with Nextline(init_options=init_options) as y:
+async def nextline(statement):
+    async with Nextline(statement) as y:
         yield y
 
 

--- a/tests/main/test_nextline.py
+++ b/tests/main/test_nextline.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from nextline import InitOptions, Nextline
+from nextline import Nextline
 
 SOURCE = """
 import time
@@ -19,14 +19,12 @@ def test_init_sync():
     '''Assert the init without the running loop.'''
     with pytest.raises(RuntimeError):
         asyncio.get_running_loop()
-    init_options = InitOptions(statement=SOURCE)
-    nextline = Nextline(init_options=init_options)
+    nextline = Nextline(SOURCE)
     assert nextline
 
 
-async def test_repr() -> None:
-    init_options = InitOptions(statement=SOURCE)
-    nextline = Nextline(init_options=init_options)
+async def test_repr():
+    nextline = Nextline(SOURCE)
     assert repr(nextline)
     async with nextline:
         assert repr(nextline)
@@ -34,8 +32,7 @@ async def test_repr() -> None:
 
 
 async def test_one() -> None:
-    init_options = InitOptions(statement=SOURCE)
-    async with Nextline(init_options=init_options) as nextline:
+    async with Nextline(SOURCE) as nextline:
         async with nextline.run_session():
             async for prompt in nextline.prompts():
                 await nextline.send_pdb_command(
@@ -56,9 +53,8 @@ async def test_timeout(machine: Mock):
         await asyncio.sleep(5)
 
     machine.close.side_effect = close
-    init_options = InitOptions(statement=SOURCE, timeout_on_exit=0.01)
     with pytest.raises(asyncio.TimeoutError):
-        async with Nextline(init_options=init_options):
+        async with Nextline(SOURCE, timeout_on_exit=0.01):
             pass
 
 

--- a/tests/main/test_nextline.py
+++ b/tests/main/test_nextline.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from nextline import InitOptions, Nextline, ResetOptions
+from nextline import InitOptions, Nextline
 
 SOURCE = """
 import time
@@ -43,8 +43,7 @@ async def test_one() -> None:
                 )
         nextline.exception()
         await nextline.reset()
-        reset_options = ResetOptions(statement=SOURCE_TWO, run_no_start_from=5)
-        await nextline.reset(reset_options=reset_options)
+        await nextline.reset(statement=SOURCE_TWO, run_no_start_from=5)
         async with nextline.run_session():
             async for prompt in nextline.prompts():
                 await nextline.send_pdb_command(

--- a/tests/main/test_prompts.py
+++ b/tests/main/test_prompts.py
@@ -1,6 +1,6 @@
 import time
 
-from nextline import InitOptions, Nextline
+from nextline import Nextline
 
 
 def func():
@@ -8,8 +8,7 @@ def func():
 
 
 async def test_one() -> None:
-    init_options = InitOptions(statement=func)
-    async with Nextline(init_options=init_options) as nextline:
+    async with Nextline(func) as nextline:
         async with nextline.run_session():
             async for prompt in nextline.prompts():
                 await nextline.send_pdb_command(
@@ -19,8 +18,7 @@ async def test_one() -> None:
 
 
 async def test_close_while_running() -> None:
-    init_options = InitOptions(statement=func)
-    async with Nextline(init_options=init_options) as nextline:
+    async with Nextline(func) as nextline:
         await nextline.run()
         async for prompt in nextline.prompts():
             await nextline.send_pdb_command('next', prompt.prompt_no, prompt.trace_no)


### PR DESCRIPTION
- Hide `InitOptions` and `ResetOptions`
- Make `trace_threads` and `trace_modules` direct options of Nextline.__init__() and Nextline.reset() 