### PR TITLE
Delay the instantiation of `Machine` until `start()`

### DIFF
--- a/nextline/fsm/state.py
+++ b/nextline/fsm/state.py
@@ -15,11 +15,10 @@ from .factory import build_state_machine
 class Machine:
     '''The finite state machine of the nextline states.'''
 
-    def __init__(self, init_options: InitOptions):
-        self.registry = PubSub[Any, Any]()
+    def __init__(self, init_options: InitOptions, registry: PubSub[Any, Any]):
         self._hook = build_hook()
         self._hook.hook.init(
-            hook=self._hook, registry=self.registry, init_options=init_options
+            hook=self._hook, registry=registry, init_options=init_options
         )
 
         self._machine = build_state_machine(model=self)
@@ -85,7 +84,6 @@ class Machine:
         return self._hook.hook.result()
 
     async def on_enter_closed(self, _: EventData) -> None:
-        await self.registry.close()
         await self._hook.ahook.close()
 
     async def on_reset(self, event: EventData) -> None:

--- a/nextline/main.py
+++ b/nextline/main.py
@@ -21,6 +21,7 @@ from .types import (
     TraceNo,
 )
 from .utils import merge_aiters
+from .utils.pubsub.broker import PubSub
 
 
 class Nextline:
@@ -70,9 +71,11 @@ class Nextline:
         logger = getLogger(__name__)
         logger.debug(f'self._init_options: {self._init_options}')
 
-        self._machine = Machine(init_options=self._init_options)
+        self._registry = PubSub[Any, Any]()
+        self._machine = Machine(
+            init_options=self._init_options, registry=self._registry
+        )
         self._timeout_on_exit = timeout_on_exit
-        self._registry = self._machine.registry
 
         self._started = False
         self._closed = False
@@ -92,6 +95,7 @@ class Nextline:
         if self._closed:
             return
         self._closed = True
+        await self._registry.close()
         await self._machine.close()  # type: ignore
         await self._continuous.close()
 

--- a/nextline/main.py
+++ b/nextline/main.py
@@ -61,7 +61,7 @@ class Nextline:
     ):
         self._continuous = Continuous(self)
 
-        init_options = InitOptions(
+        self._init_options = InitOptions(
             statement=statement,
             run_no_start_from=run_no_start_from,
             trace_threads=trace_threads,
@@ -69,9 +69,9 @@ class Nextline:
         )
 
         logger = getLogger(__name__)
-        logger.debug(f'init_options: {reprlib.repr(init_options)}')
+        logger.debug(f'self._init_options: {reprlib.repr(self._init_options)}')
 
-        self._machine = Machine(init_options=init_options)
+        self._machine = Machine(init_options=self._init_options)
         self._timeout_on_exit = timeout_on_exit
         self._registry = self._machine.registry
 

--- a/nextline/main.py
+++ b/nextline/main.py
@@ -1,6 +1,5 @@
 import asyncio
 import linecache
-import reprlib
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from logging import getLogger
@@ -69,7 +68,7 @@ class Nextline:
         )
 
         logger = getLogger(__name__)
-        logger.debug(f'self._init_options: {reprlib.repr(self._init_options)}')
+        logger.debug(f'self._init_options: {self._init_options}')
 
         self._machine = Machine(init_options=self._init_options)
         self._timeout_on_exit = timeout_on_exit
@@ -176,7 +175,7 @@ class Nextline:
             trace_modules=trace_modules,
         )
         logger = getLogger(__name__)
-        logger.debug(f'reset_options: {reprlib.repr(reset_options)}')
+        logger.debug(f'reset_options: {reset_options}')
         await self._machine.reset(  # type: ignore
             reset_options=reset_options,
         )

--- a/nextline/main.py
+++ b/nextline/main.py
@@ -59,24 +59,15 @@ class Nextline:
         trace_modules: bool = False,
         timeout_on_exit: float = 3,
     ):
-        self._continuous = Continuous(self)
-
         self._init_options = InitOptions(
             statement=statement,
             run_no_start_from=run_no_start_from,
             trace_threads=trace_threads,
             trace_modules=trace_modules,
         )
-
-        logger = getLogger(__name__)
-        logger.debug(f'self._init_options: {self._init_options}')
-
+        self._continuous = Continuous(self)
         self._registry = PubSub[Any, Any]()
-        self._machine = Machine(
-            init_options=self._init_options, registry=self._registry
-        )
         self._timeout_on_exit = timeout_on_exit
-
         self._started = False
         self._closed = False
 
@@ -88,6 +79,11 @@ class Nextline:
         if self._started:
             return
         self._started = True
+        logger = getLogger(__name__)
+        logger.debug(f'self._init_options: {self._init_options}')
+        self._machine = Machine(
+            init_options=self._init_options, registry=self._registry
+        )
         await self._continuous.start()
         await self._machine.initialize()  # type: ignore
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 dependencies = [
     "apluggy>=0.9",
     "tblib>=1.7",
+    "exceptiongroup>=1.2",
     "transitions>=0.9",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
so that `InitOptions` can be modified between `__init__()` and `start()`