### PR TITLE
Rename `close()` to `aclose()` in `PubSubItem`

### DIFF
--- a/nextline/continuous.py
+++ b/nextline/continuous.py
@@ -29,7 +29,7 @@ class Continuous:
         await self._task
         if self._tasks:
             await asyncio.gather(*self._tasks)
-        await self._pubsub_enabled.close()
+        await self._pubsub_enabled.aclose()
 
     async def __aenter__(self) -> 'Continuous':
         await self.start()

--- a/nextline/utils/pubsub/broker.py
+++ b/nextline/utils/pubsub/broker.py
@@ -41,7 +41,7 @@ class PubSub(Generic[_KT, _VT]):
 
         """
         if q := self._queue.pop(key, None):
-            await q.close()
+            await q.aclose()
 
     async def close(self) -> None:
         """End all subscriptions for all keys
@@ -52,7 +52,7 @@ class PubSub(Generic[_KT, _VT]):
         """
         while self._queue:
             _, q = self._queue.popitem()
-            await q.close()
+            await q.aclose()
 
     async def __aenter__(self) -> "PubSub[_KT, _VT]":
         return self

--- a/nextline/utils/pubsub/item.py
+++ b/nextline/utils/pubsub/item.py
@@ -69,7 +69,7 @@ class PubSubItem(Generic[_Item]):
     >>> async def distributor_rest(obj):
     ...     for i in items[2:]:
     ...         await obj.publish(i)
-    ...     await obj.close()
+    ...     await obj.aclose()
 
     The second distributor calls the method `close()` to end the subscriptions.
     The method `subscribe()` will return when the method `close()` is called.
@@ -161,7 +161,7 @@ class PubSubItem(Generic[_Item]):
         finally:
             self._queues.remove(q)
 
-    async def close(self) -> None:
+    async def aclose(self) -> None:
         '''End gracefully'''
         self._lock_close = self._lock_close or Condition()
         async with self._lock_close:
@@ -174,7 +174,7 @@ class PubSubItem(Generic[_Item]):
         return self
 
     async def __aexit__(self, *_: Any, **__: Any) -> None:
-        await self.close()
+        await self.aclose()
 
     async def _enumerate(self, item: _Item | _End) -> None:
         self._idx += 1

--- a/tests/utils/pubsub/test_item.py
+++ b/tests/utils/pubsub/test_item.py
@@ -15,8 +15,8 @@ async def test_close() -> None:
 
 async def test_close_multiple_times() -> None:
     async with PubSubItem[str]() as obj:
-        await obj.close()
-        await obj.close()
+        await obj.aclose()
+        await obj.aclose()
 
 
 @given(...)
@@ -42,7 +42,7 @@ async def test_subscribe(items: Sequence[str], n_subscriptions: int) -> None:
         async def send() -> None:
             async for i in aiterable(items):
                 await obj.publish(i)
-            await obj.close()
+            await obj.aclose()
 
         *results, _ = await asyncio.gather(
             *(receive() for _ in range(n_subscriptions)),
@@ -90,7 +90,7 @@ async def test_last(
         async def send() -> None:
             async for i in aiterable(items):
                 await obj.publish(i)
-            await obj.close()
+            await obj.aclose()
 
         for i in pre_items:
             await obj.publish(i)
@@ -159,7 +159,7 @@ async def test_break(data: st.DataObject) -> None:
         async def send() -> None:
             async for i in aiterable(items):
                 await obj.publish(i)
-            await obj.close()
+            await obj.aclose()
 
         results, _ = await asyncio.gather(receive(), send())
     assert results == expected
@@ -194,7 +194,7 @@ async def test_no_missing_or_duplicate(data: st.DataObject) -> None:
             event.set()
             async for i in aiterable(post_items):
                 await obj.publish(i)
-            await obj.close()
+            await obj.aclose()
 
         *results, _ = await asyncio.gather(
             *(receive() for _ in range(n_subscriptions)),


### PR DESCRIPTION
So as to work with [contextlib.aclosing](https://docs.python.org/3/library/contextlib.html#contextlib.aclosing)