### PR TITLE
Replace `sys.gettrace()` with `threading.gettrace()`

### DIFF
--- a/nextline/spawned/call.py
+++ b/nextline/spawned/call.py
@@ -65,7 +65,7 @@ def sys_trace(
 
     try:
         yield
-    finally:
+    finally:  # pragma: no cover
         sys.settrace(org_sys)
         if thread:
             threading.settrace(org_threading)  # type: ignore

--- a/nextline/spawned/call.py
+++ b/nextline/spawned/call.py
@@ -55,7 +55,8 @@ def sys_trace(
     the finally clause.
 
     '''
-    trace_func_org = sys.gettrace()
+    org_threading = threading.gettrace()
+    org_sys = sys.gettrace()
 
     if thread:
         threading.settrace(trace_func)
@@ -65,6 +66,6 @@ def sys_trace(
     try:
         yield
     finally:
-        sys.settrace(trace_func_org)
+        sys.settrace(org_sys)
         if thread:
-            threading.settrace(trace_func_org)  # type: ignore
+            threading.settrace(org_threading)  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ log_cli_level = "INFO"
 [tool.coverage.run]
 branch = true
 source = ["nextline", "tests"]
-concurrency = ["multiprocessing"]
+concurrency = ["multiprocessing", "thread"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,8 @@ import pytest
 @pytest.fixture(autouse=True)
 def recover_trace() -> Iterator[None]:
     """Set the original trace function back after each test"""
-    trace_org = sys.gettrace()
+    org_threading = threading.gettrace()
+    org_sys = sys.gettrace()
     yield
-    sys.settrace(trace_org)
-    threading.settrace(trace_org)  # type: ignore
+    sys.settrace(org_sys)
+    threading.settrace(org_threading)  # type: ignore

--- a/tests/spawned/test_call.py
+++ b/tests/spawned/test_call.py
@@ -1,4 +1,5 @@
 import sys
+import threading
 import traceback
 from threading import Thread
 from typing import NoReturn
@@ -16,7 +17,7 @@ def trace() -> Mock:
     return f
 
 
-def test_simple(trace: Mock) -> None:
+def test_simple(trace: Mock) -> None:  # pragma: no cover
     def func() -> int:
         x = 123
         return x
@@ -33,7 +34,7 @@ class MockError(Exception):
     pass
 
 
-def test_raise(trace: Mock) -> None:
+def test_raise(trace: Mock) -> None:  # pragma: no cover
     def func() -> NoReturn:
         raise MockError()
 
@@ -66,7 +67,7 @@ def test_raise(trace: Mock) -> None:
 
 
 @pytest.mark.parametrize("thread", [True, False])
-def test_threading(trace: Mock, thread: bool) -> None:
+def test_threading(trace: Mock, thread: bool) -> None:  # pragma: no cover
     def f1() -> None:
         return
 
@@ -75,12 +76,14 @@ def test_threading(trace: Mock, thread: bool) -> None:
         t1.start()
         t1.join()
 
-    trace_org = sys.gettrace()
+    trace_org_threading = threading.gettrace()
+    trace_org_sys = sys.gettrace()
 
     with sys_trace(trace):
         func()
 
-    assert trace_org == sys.gettrace()
+    assert trace_org_sys == sys.gettrace()
+    assert trace_org_threading == threading.gettrace()
 
     traced = {
         (c.args[0].f_globals.get("__name__"), c.args[0].f_code.co_name)


### PR DESCRIPTION
- This PR makes the coverage more accurate.
- `threading.gettrace()` is new in Python 3.10